### PR TITLE
Keep reference to underlying file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.intception/blob-storage "0.4.2"
+(defproject com.intception/blob-storage "0.4.3"
   :description "Blob Storage Library"
   :url "https://github.com/intception/blob-storage"
   :license {:name "Eclipse Public License"

--- a/src/blob_storage/coerce.clj
+++ b/src/blob_storage/coerce.clj
@@ -65,3 +65,13 @@
   "Creates an InputStream from a blob. The blob can be a file or a byte array"
   [blob]
   (io/input-stream blob))
+
+(defn blob->file
+  "If the blob has a file key, then return it, otherwise
+   create a temporary file and copy the blob to it."
+  [{:keys [blob file]}]
+  (if file
+    file
+    (let [temp-file (File/createTempFile "blob-storage" ".bin")]
+      (io/copy blob temp-file)
+      temp-file)))

--- a/src/blob_storage/postgres/schema.clj
+++ b/src/blob_storage/postgres/schema.clj
@@ -80,6 +80,9 @@
       (some-> row
               (th/when-> (:oid row)
                 (assoc :blob (large-object->file conn (:oid row))))
+              (th/when-> (:oid row)
+                ;; don't lose the reference to the file
+                (#(assoc % :file (:blob %))))
               (clojure.core/update :blob #(io/input-stream %))
               ;; internal implementation detail, no need to expose it
               (dissoc :oid)))))

--- a/test/blob_storage/postgres_test.clj
+++ b/test/blob_storage/postgres_test.clj
@@ -46,6 +46,7 @@
             blob-meta (b/blob-metadata service blob-id)]
         (is (instance? java.io.InputStream (:blob stored-blob)))
         (is (instance? java.io.BufferedInputStream (:blob stored-blob)))
+        (is (nil? (:file stored-blob)))
         (is (= 99 (alength (bc/blob->bytes (:blob stored-blob)))) "Incorrect blob length")
         (is (= blob-meta (dissoc stored-blob :blob)))))
 
@@ -57,5 +58,6 @@
         (is (not (bytes? (:blob stored-blob))) "Blob should be afile")
         (is (instance? java.io.InputStream (:blob stored-blob)))
         (is (instance? java.io.BufferedInputStream (:blob stored-blob)))
+        (is (instance? java.io.File (:file stored-blob)))
         (is (= 101 (alength (bc/blob->bytes (:blob stored-blob)))) "Incorrect blob length")
         (is (= blob-meta (dissoc stored-blob :blob)))))))


### PR DESCRIPTION
InputStream can only be read once (unless .reset is called with may not be supported)